### PR TITLE
Fix mouse coordinates for scaled canvas

### DIFF
--- a/battle.js
+++ b/battle.js
@@ -90,8 +90,8 @@ function playerHeal(hp){
 
 function flashmove(event){
     if(onBattle){
-        let x=Math.floor(event.offsetX/50);
-        let y=Math.floor(event.offsetY/50);
+        let x=Math.floor(event.offsetX*scaleX/50);
+        let y=Math.floor(event.offsetY*scaleY/50);
         if(x==player.X&&y==player.Y){
             return 0;
         }
@@ -112,8 +112,8 @@ function flashmove(event){
 }
 function fireball(event){
     if(onBattle){
-        let x=Math.floor(event.offsetX/50);
-        let y=Math.floor(event.offsetY/50);
+        let x=Math.floor(event.offsetX*scaleX/50);
+        let y=Math.floor(event.offsetY*scaleY/50);
         console.log(x,y);
         let dx=x-player.X;
         let dy=y-player.Y;

--- a/common.js
+++ b/common.js
@@ -1,6 +1,9 @@
 var info;
 var canvas;
 var context;
+var rect;
+var scaleX;
+var scaleY;
 
 var choiceSet;
 
@@ -118,8 +121,11 @@ var seed=""+Math.floor(Math.random()*Math.pow(10,16))+Math.floor(Math.random()*M
 
 
 function Click(event){
-    let X=floor(event.offsetX/50);
-    let Y=floor(event.offsetY/50);
+    rect=canvas.getBoundingClientRect();
+    scaleX=canvas.width/rect.width;
+    scaleY=canvas.height/rect.height;    
+    let X=floor(event.offsetX*scaleX/50);
+    let Y=floor(event.offsetY*scaleY/50);
     if(startReady===1){
         if(imageReady){
             startReady=-1;
@@ -161,6 +167,9 @@ function Click(event){
 }
 var mouseMoveCd=0;
 function onMouseMove(event){
+    rect=canvas.getBoundingClientRect();
+    scaleX=canvas.width/rect.width;
+    scaleY=canvas.height/rect.height;
     if(mouseMoveCd||onBattle==0){
         return;
     }
@@ -169,8 +178,8 @@ function onMouseMove(event){
         mouseMoveCd=0;
     },50);
     // console.log(event);
-    let mx=floor(event.offsetX/50);
-    let my=floor(event.offsetY/50);
+    let mx=floor(event.offsetX*scaleX/50);
+    let my=floor(event.offsetY*scaleY/50);
     mouseX=mx;
     mouseY=my;
     // console.log(`${mx}, ${my}`);

--- a/index.html
+++ b/index.html
@@ -8,8 +8,12 @@
             #Container{
                 position: relative;
                 margin: 5px;
-                width: 90%;
+                width: 95%;
                 max-width: 1600px;
+            }
+            #mainCanvas{
+                width:100%;
+                object-fit: contain;
             }
             .choice{
                 position: absolute; 
@@ -68,6 +72,9 @@
                 console.log(e.offsetX+','+e.offsetY);
             })
             info.appendChild(document.createTextNode(seed));
+            rect=canvas.getBoundingClientRect();
+            scaleX=canvas.width/rect.width;
+            scaleY=canvas.height/rect.height;
             preset();
             frontPage();
         }
@@ -76,7 +83,7 @@
         <h1>A simple turn-based game</h1>
 
         <div id="Container">
-            <canvas id="mainCanvas" width="1600" height="900" style="display: block; margin: 0px; padding: 0px; outline:none; border: 3px solid palegreen;" tabindex="999" onclick="Click(event)" onmousemove="onMouseMove(event)" onkeypress="keyPress(event)">
+            <canvas id="mainCanvas" width="1600px" height="900px" style="display: block; margin: 0px; padding: 0px; outline:none; border: 3px solid palegreen;" tabindex="999" onclick="Click(event)" onmousemove="onMouseMove(event)" onkeypress="keyPress(event)">
                 
             </canvas>
 


### PR DESCRIPTION
Account for CSS/responsive scaling when mapping pointer events to canvas grid. Introduce rect, scaleX, and scaleY and compute them from canvas.getBoundingClientRect(); multiply event.offsetX/offsetY by scale factors in Click, onMouseMove, flashmove, and fireball. Make the canvas responsive (Container width 95%, canvas width:100% and object-fit:contain) and initialize scale values on startup. This ensures clicks and mouse moves target the correct in-canvas coordinates when the canvas is resized by CSS.