### PR TITLE
Skip mouseover for defeated enemies

### DIFF
--- a/event.js
+++ b/event.js
@@ -100,7 +100,7 @@ function checkSelector(){
     let isTroopSelected=0;
     enemy.forEach(emy=>{
         emy.updateSelector();
-        if(isTargetOnMouseOver(emy)&&currentStage=="battle"){
+        if(isTargetOnMouseOver(emy)&&currentStage=="battle"&&!emy.isDefeat){
             emy.onMouseOver();
             isTroopSelected=1;
         }


### PR DESCRIPTION
Prevent defeated enemy units from receiving mouseover handling during battle. The checkSelector function now only calls emy.onMouseOver() when currentStage == "battle" and emy.isDefeat is false, avoiding selection/highlighting of troops already marked as defeated.