### PR TITLE
Refactor game state to Maps and turn system

### DIFF
--- a/battle.js
+++ b/battle.js
@@ -1,5 +1,5 @@
 function checkScene(){
-    if(currentStage=="battle"&&enemyAlive==0){
+    if(currentStage=="battle"&&enemy.length==0){
         currentStage="intermission";
         setChoice();
         clearProjectile();

--- a/character.js
+++ b/character.js
@@ -1,6 +1,6 @@
-var character=[];
+var character=new Map();
 
-character.push({
+character.set("Lagrange",{
     id:"Lagrange",
     source:"Lagrange.jpg",
     mhp:150,
@@ -36,7 +36,7 @@ character.push({
         displayDescription(this);
     }
 });
-character.push({
+character.set("Tairitsu",{
     id:"Tairitsu",
     source:"Tairitsu.png",
     mhp:100,
@@ -73,7 +73,7 @@ character.push({
         displayDescription(this);
     }
 });
-character.push({
+character.set("Tairitsu-Tempest",{
     id:"Tairitsu-Tempest",
     source:"Tairitsu.png",
     mhp:300,
@@ -94,7 +94,7 @@ character.push({
         description:{
             id:"Tairitsu",
             icon:"Tairitsu.png",
-            text:`黑暗常伴的少女。`,
+            text:`她是迫近的风暴。`,
         }
     },
     onClick(){
@@ -105,7 +105,7 @@ character.push({
         displayDescription(this);
     }
 });
-character.push({
+character.set("Hikari",{
     id:"Hikari",
     source:"Hikari.png",
     mhp:200,
@@ -145,7 +145,7 @@ character.push({
 function setCharacter(charId){
     let chara;
     if(typeof charId=="object") chara=charId;
-    if(typeof charId=="string") chara=character.find(char=>char.id==charId);
+    if(typeof charId=="string") chara=character.get(charId);
     console.log(chara);
     player.source=chara.source;
     player.baseMhp=chara.mhp;

--- a/draw.js
+++ b/draw.js
@@ -130,31 +130,33 @@ function drawProjectile(){
 
 function drawSkillStat(){
     context.clearRect(50,660,700,100);
-    for(let i=0;i<skillCount;i++){
-        if(!skill[i+1].cdt){
-            drawImgZoom(skill[i+1].source,100*i+50,660,80,80);
+    let i=0;
+    for(let [id,skil] of skill){
+        if(!skil.cdt){
+            drawImgZoom(skil.source,100*i+50,660,80,80);
         }
         else{
-            drawImgZoom(skill[i+1].sourceCD,100*i+50,660,80,80);
+            drawImgZoom(skil.sourceCD,100*i+50,660,80,80);
 
                 context.fillStyle="black";
                 context.font="60px Arial";
-                context.fillText(`${skill[i+1].cdt}`,100*i+25+50,720);
+                context.fillText(`${skil.cdt}`,100*i+25+50,720);
 
         }
         
-        if(skill[i+1].cost>player.mp){
+        if(skil.cost>player.mp){
             context.fillStyle="red";
         }
         else{
             context.fillStyle="blue";
         }
         context.font="20px Arial";
-        context.fillText(`${skill[i+1].cost}`,100*i+80+50,760);
-        if(skill[i+1].isSelected){
+        context.fillText(`${skil.cost}`,100*i+80+50,760);
+        if(skil.isSelected){
             drawSelectSkill(i+1);
-            skill[i+1].drawSelector();
-        }        
+            skil.drawSelector();
+        }
+        i++;
     }
 }
 
@@ -325,10 +327,10 @@ function drawChoiceSlot(){
     })
 }
 function drawCharacterChoice(){
-    character.forEach(slot=>{
+    for(let [id,slot] of character){
         if(slot.isSelectable)
         drawImgZoom(slot.source,slot.selector.offsetX,slot.selector.offsetY,slot.selector.width,slot.selector.height);
-    })
+    }
 }
 
 function drawPlayerEffects(){

--- a/effects.js
+++ b/effects.js
@@ -1,19 +1,38 @@
-var effectType={};
+var effectType=new Map();
 
-effectType.poison={
+effectType.set("poison",{
     id:"poison",
     source:"poison.png",
     gain(target){
         return 0;
     },
-    turnStart(target){
+    playerTurnStart(target){
         target.hp=max(1,target.hp-target.mhp*0.05);
+        console.log("poison damage");
         return 1;
     },
-    turnMiddle(target){
+    playerTurnMiddle(target){
         return 0;
     },
-    turnEnd(target){
+    playerTurnEnd(target){
+        return 0;
+    },
+    neutralTurnStart(target){
+        return 0;
+    },
+    neutralTurnMiddle(target){
+        return 0;
+    },
+    neutralTurnEnd(target){
+        return 0;
+    },
+    enemyTurnStart(target){
+        return 0;
+    },
+    enemyTurnMiddle(target){
+        return 0;
+    },
+    enemyTurnEnd(target){
         return 0;
     },
     expire(target){
@@ -34,24 +53,42 @@ effectType.poison={
             text:"poisonous"
         }
     }
-}
-effectType.immortal={
+});
+effectType.set("immortal",{
     id:"immortal",
     source:"immortal.png",
     gain(target){
         return 0;
     },
-    turnStart(target){  //不影响伤害结算
-        
+    playerTurnStart(target){  //不影响伤害结算
         return 0;
     },
-    turnMiddle(target){
+    playerTurnMiddle(target){
         target.hp=max(target.hp,1);
         return 0;
     },
-    turnEnd(target){
+    playerTurnEnd(target){
+        return 0;
+    },
+    neutralTurnStart(target){
+        return 0;
+    },
+    neutralTurnMiddle(target){
+        target.hp=max(target.hp,1);
+        return 0;
+    },
+    neutralTurnEnd(target){
+        return 0;
+    },
+    enemyTurnStart(target){
+        return 0;
+    },
+    enemyTurnMiddle(target){
         target.hp=max(target.hp,1);
         return 1;
+    },
+    enemyTurnEnd(target){
+        return 0;
     },
     expire(target){
         return 0;
@@ -71,17 +108,17 @@ effectType.immortal={
             text:"immortal"
         }
     }
-}
-effectType.revival={
+});
+effectType.set("revival",{
     id:"revival",
     source:"revival.png",
     gain(target){
         return 0;
     },
-    turnStart(target){
+    playerTurnStart(target){
         return 0;
     },
-    turnMiddle(target){
+    playerTurnMiddle(target){
         if(target.hp<=0){
             target.hp=target.mhp*0.5;
             giveEffect(target,"immortal",5,false);
@@ -89,12 +126,35 @@ effectType.revival={
         }
         return 0;
     },
-    turnEnd(target){
+    playerTurnEnd(target){
+        return 0;
+    },
+    neutralTurnStart(target){
+        return 0;
+    },
+    neutralTurnMiddle(target){
         if(target.hp<=0){
             target.hp=target.mhp*0.5;
             giveEffect(target,"immortal",5,false);
             return 1;
         }
+        return 0;
+    },
+    neutralTurnEnd(target){
+        return 0;
+    },
+    enemyTurnStart(target){
+        return 0;
+    },
+    enemyTurnMiddle(target){
+        if(target.hp<=0){
+            target.hp=target.mhp*0.5;
+            giveEffect(target,"immortal",5,false);
+            return 1;
+        }
+        return 0;
+    },
+    enemyTurnEnd(target){
         return 0;
     },
     expire(target){
@@ -116,12 +176,42 @@ effectType.revival={
             text:"revive"
         }
     }
-}
-effectType.void={
+});
+effectType.set("void",{
     id:"void",
     source:"poison.png",
-    trigger(entity){
-        ;
+    gain(target){
+        return 0;
+    },
+    playerTurnStart(target){
+        return 0;
+    },
+    playerTurnMiddle(target){
+        return 0;
+    },
+    playerTurnEnd(target){
+        return 0;
+    },
+    neutralTurnStart(target){
+        return 0;
+    },
+    neutralTurnMiddle(target){
+        return 0;
+    },
+    neutralTurnEnd(target){
+        return 0;
+    },
+    enemyTurnStart(target){
+        return 0;
+    },
+    enemyTurnMiddle(target){
+        return 0;
+    },
+    enemyTurnEnd(target){
+        return 0;
+    },
+    expire(target){
+        return 0;
     },
     maxDuration:10,
     isSelectable:false,
@@ -138,9 +228,9 @@ effectType.void={
             text:"void"
         }
     }
-}
+});
 function giveEffect(entity,effectId,duration,isCrossRound){
-    let type=effectType[effectId];
+    let type=effectType.get(effectId);
     let i=entity.effect.findIndex(eff=>eff.id==type.id);
     if(i!=-1){
         entity.effect[i].duration=min(type.maxDuration,entity.effect[i].duration+duration);
@@ -149,9 +239,15 @@ function giveEffect(entity,effectId,duration,isCrossRound){
             id:type.id,
             source:type.source,
             gain:type.gain,
-            turnStart:type.turnStart,
-            turnMiddle:type.turnMiddle,
-            turnEnd:type.turnEnd,
+            playerTurnStart:type.playerTurnStart,
+            playerTurnMiddle:type.playerTurnMiddle,
+            playerTurnEnd:type.playerTurnEnd,
+            neutralTurnStart:type.neutralTurnStart,
+            neutralTurnMiddle:type.neutralTurnMiddle,
+            neutralTurnEnd:type.neutralTurnEnd,
+            enemyTurnStart:type.enemyTurnStart,
+            enemyTurnMiddle:type.enemyTurnMiddle,
+            enemyTurnEnd:type.enemyTurnEnd,
             expire:type.expire,
             duration:duration,
             isSelectable:type.isSelectable,
@@ -178,18 +274,39 @@ function giveEffect(entity,effectId,duration,isCrossRound){
     }
 
 }
-function activateEnemyEffects(timing){
-    enemy.forEach(emy=>activateEffects(emy,timing));
+function activateEnemyEffects(turn,timing){
+    enemy.forEach(emy=>activateEffects(emy,turn,timing));
 }
 
-function activateEffects(entity,timing){
-    entity.effect.forEach(eff=>{
-        switch(timing){
-            case "turnStart":
-                if(eff.duration>0&&eff.turnStart(entity)) eff.duration--;
+function activateEffects(entity,turn,timing){
+    for(let eff of entity.effect){
+        switch(turn+timing){
+            case "playerTurnStart":
+                if(eff.duration>0&&eff.playerTurnStart(entity)) eff.duration--;
                 break;
-            case "turnEnd":
-                if(eff.duration>0&&eff.turnEnd(entity)) eff.duration--;
+            case "playerTurnMiddle":
+                if(eff.duration>0&&eff.playerTurnMiddle(entity)) eff.duration--;
+                break;
+            case "playerTurnEnd":
+                if(eff.duration>0&&eff.playerTurnEnd(entity)) eff.duration--;
+                break;
+            case "neutralTurnStart":
+                if(eff.duration>0&&eff.neutralTurnStart(entity)) eff.duration--;
+                break;
+            case "neutralTurnMiddle":
+                if(eff.duration>0&&eff.neutralTurnMiddle(entity)) eff.duration--;
+                break;
+            case "neutralTurnEnd":
+                if(eff.duration>0&&eff.neutralTurnEnd(entity)) eff.duration--;
+                break;
+            case "enemyTurnStart":
+                if(eff.duration>0&&eff.enemyTurnStart(entity)) eff.duration--;
+                break;
+            case "enemyTurnMiddle":
+                if(eff.duration>0&&eff.enemyTurnMiddle(entity)) eff.duration--;
+                break;
+            case "enemyTurnEnd":
+                if(eff.duration>0&&eff.enemyTurnEnd(entity)) eff.duration--;
                 break;
             default:
                 break;
@@ -198,7 +315,7 @@ function activateEffects(entity,timing){
             eff.expire(entity);
             entity.effect.splice(entity.effect.findIndex((eff1)=>eff1==eff),1);
         }
-    })
+    }
 }
 
 function giveVoidEffect(entity){

--- a/enemy.js
+++ b/enemy.js
@@ -1,6 +1,6 @@
 var enemy=[];
-var enemyType={};
-enemyType["Kanade"]={
+var enemyType=new Map();
+enemyType.set("Kanade",{
     id:"Kanade",
     source:"Enemy1.jpg",
     mhp:80,
@@ -25,8 +25,12 @@ enemyType["Kanade"]={
     action(){
         enemyActionUsual(this);
     }
-}
-function addEnemy(type){
+});
+function addEnemy(typeId){
+    let type;
+    if(typeof typeId=="object")type=typeId;
+    else if(typeof typeId=="string")type=enemyType.get(typeId);
+    else return 0;
     enemyCount++;
     enemyAlive++;
     enemy.push({
@@ -79,7 +83,7 @@ function addEnemy(type){
         },
         onClick(){
             if(player.attack(this)){
-                drawBattlefield();
+                playerTurn();
             }
         }   
     })
@@ -88,7 +92,7 @@ function addEnemy(type){
 
 function summonEnemy(Id,quantity){
     for(let i=1;i<=quantity;i++){
-        addEnemy(enemyType[Id]);
+        addEnemy(Id);
     }
     enemyInround+=quantity;
     enemy.forEach(emy=>{

--- a/event.js
+++ b/event.js
@@ -22,16 +22,17 @@ function Click(event){
         checkOnClick();
     }
     if(currentStage=="battle"&&skillReady){
+        let skil=skill.get(skillReady);
         if(isPosLegal(mouseX,mouseY)){
-            if(skill[skillReady].spell(event)){
-                skill[skillReady].cdt=skill[skillReady].cd+1;
-                player.mp-=skill[skillReady].cost;
+            if(skil.spell(event)){
+                skil.cdt=skil.cd+1;
+                player.mp-=skil.cost;
             }
-            skill[skillReady].isSelected=0;
+            skil.isSelected=0;
             skillReady=0;
             drawSkillStat();
         }else{
-            skill[skillReady].isSelected=0;
+            skil.isSelected=0;
             skillReady=0;
             checkOnClick();
         }      
@@ -87,92 +88,103 @@ function keyPress(e){
     if(e.key=="w"||e.key=="a"||e.key=="s"||e.key=="d"||e.key==" "){
         
         if(skillReady){
-            skill[skillReady].isSelected=0;
+            skill.get(skillReady).isSelected=0;
             skillReady=0;
             // drawSkillStat();
         }
         playerMove(e.key);
     }
     if(e.key>="1"&&e.key<="9"&&currentStage=="battle"){
-        playSkill(+e.key);
+        prepareSkill(+e.key);
     }
 }
 function checkSelector(){
-    let isTroopSelected=0;
-    enemy.forEach(emy=>{
+    for(let emy of enemy){
         emy.updateSelector();
         if(isTargetOnMouseOver(emy)&&currentStage=="battle"&&!emy.isDefeat){
             emy.onMouseOver();
-            isTroopSelected=1;
+            return;
         }
-    })
-    skill.forEach(skil=>{
+    }
+    for(let [id,skil] of skill){
         if(isTargetOnMouseOver(skil)&&currentStage=="battle"){
             skil.onMouseOver();
+            return;
         }
-    })
+    }
     player.updateSelector();
     if(isTargetOnMouseOver(player)&&currentStage=="battle"){
         player.onMouseOver();
-        isTroopSelected=1;
+        return;
     }
-    key.forEach(k=>{
+    for(let k of key){
         if(isTargetOnMouseOver(k)&&currentStage=="battle"){
             k.onMouseOver();
+            return;
         }
-    })
-    choiceSlot.forEach(slot=>{
+    }
+    for(let slot of choiceSlot){
         if(isTargetOnMouseOver(slot)&&currentStage=="intermission"&&!choiceChosen){
             slot.onMouseOver();
+            return;
         }
-    })
-    character.forEach(chara=>{
+    }
+    for(let [id,chara] of character){
         if(isTargetOnMouseOver(chara)&&currentStage=="prologue"){
             chara.onMouseOver();
+            return;
         }
-    })
-    if(!isTroopSelected)
-    block.forEach(bloc=>{
+    }
+
+    for(let bloc of block){
         if(isTargetOnMouseOver(bloc)&&currentStage=="battle"){
             bloc.onMouseOver();
+            return;
         }
-    })
-    player.effect.forEach(eff=>{
+    }
+    for(let eff of player.effect){
         if(isTargetOnMouseOver(eff)&&currentStage=="battle"){
             eff.onMouseOver();
+            return;
         }
-    })
+    }
 }
 function checkOnClick(){
-    enemy.forEach(emy=>{
+    for(let emy of enemy){
         if(isTargetOnMouseOver(emy)&&currentStage=="battle"){
             emy.onClick();
+            return;
         }
-    })
-    key.forEach(k=>{
+    }
+    for(let k of key){
         if(isTargetOnMouseOver(k)&&currentStage=="battle"){
             k.onClick();
+            return;
         }
-    })
-    skill.forEach(skil=>{
+    }
+    for(let [id,skil] of skill){
         if(isTargetOnMouseOver(skil)&&currentStage=="battle"){
             skil.onClick();
+            return;
         }
-    })
+    }
     player.updateSelector();
     if(isTargetOnMouseOver(player)&&currentStage=="battle"){
         player.onClick();
+        return;
     }
-    choiceSlot.forEach(slot=>{
+    for(let slot of choiceSlot){
         if(isTargetOnMouseOver(slot)&&currentStage=="intermission"&&!choiceChosen){
             slot.onClick();
+            return;
         }
-    })
-    character.forEach(chara=>{
+    }
+    for(let [id,chara] of character){
         if(isTargetOnMouseOver(chara)&&currentStage=="prologue"){
             chara.onClick();
+            return;
         }
-    })
+    }
 }
 function isTargetOnMouseOver(target){
     if(target.selector.offsetX<mouseOffsetX&&target.selector.offsetY<mouseOffsetY&&target.selector.offsetX+target.selector.width>mouseOffsetX&&target.selector.offsetY+target.selector.height>mouseOffsetY) return true;

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ function beginRound(){
     round++;
     loadMap(random(0,map.length-1));
     summonEnemy("Kanade",min(20,2+round));
-    requestAnimationFrame(drawBattlefield);
+    playerTurn();
 }
 function frontPage(){
     clearCanvas();
@@ -49,73 +49,71 @@ function intermissonPage(){
     if(!choiceChosen) drawChoiceSlot();
 }
 
-function drawBattlefield(){
-    clearCanvas();
-    //player's turn
-    activateEffects(player,"turnStart");
-    activateEnemyEffects("turnStart");
-    
-    drawPlayerEffects();
-    drawMesh();
-    drawBlocks();
-    drawKeys();
-    drawImgZoom(player.source,player.X*50+5,player.Y*50+5,40,40);
-    drawPlayerAttackRange();
-    
-    projectileMove();
-
-    activateBlockEffectAll();
-    
-
-    activateEnemyEffects("turnMiddle");
-    checkEnemyStat();
-    enemy.forEach(emy=>{emy.updateState();});
-
-    drawProjectile();
-    drawEnemy();
-    drawEnemyStat();
-    drawPlayerStat();
-    
-    //enemy turn
-    
-    enemy.forEach(emy=>{emy.action();});
-    projectile.forEach(proj=>{
-        if(isProjectileTriggered(proj)){
-            triggerProjectile(proj);
-        }
-    })
-
-    activateEnemyEffects("turnEnd");
-    checkEnemyStat();
-    enemy.forEach(emy=>{emy.updateState();});
+function playerTurn(act,target){
+    activateEffects(player,"player","TurnStart");
+    activateEnemyEffects("player","TurnStart");
+    player.action(act,target);
+    for(let proj of projectile){
+        if(isProjectileTriggered(proj))triggerProjectile(proj);
+    }
     cdDown(cooldownPerTurn);
-    drawSkillStat();
-    setTimeout(() => {
-        clearBattlefield();
-
-        drawMesh();
-        drawBlocks();
-        drawKeys();
-        drawImgZoom(player.source,player.X*50+5,player.Y*50+5,40,40);
-        drawPlayerAttackRange();
-        drawProjectile();
-
-        checkEnemyStat();
-        enemy.forEach(emy=>{emy.updateState();});
-        drawEnemy();
-        drawEnemyStat();
-        activateEffects(player,"turnEnd");
-        drawPlayerEffects();
-        checkPlayerStat();
-        drawPlayerStat();
-        checkScene();
-    }, 80);
+    activateEffects(player,"player","TurnMiddle");
+    activateEnemyEffects("player","TurnMiddle");
+    checkEnemyStat();
+    checkPlayerStat();
     if(player.mp<player.mmp*0.3){
         recoverMP(player.mmp*0.01);
     }
+    activateEffects(player,"player","TurnEnd");
+    activateEnemyEffects("player","TurnEnd");
+    drawBattlefieldStatic();
+    checkScene();
+    neutralTurn();
+}
+function neutralTurn(){
+    activateBlockEffectAll();
+    activateEffects(player,"neutral","TurnStart");
+    activateEnemyEffects("neutral","TurnStart");
+    projectileMove();
+    for(let proj of projectile){
+        if(isProjectileTriggered(proj))triggerProjectile(proj);
+    }
+    activateEffects(player,"neutral","TurnMiddle");
+    activateEnemyEffects("neutral","TurnMiddle");
+    checkEnemyStat();
+    checkPlayerStat();
+    activateEffects(player,"neutral","TurnEnd");
+    activateEnemyEffects("neutral","TurnEnd");
+    drawBattlefieldStatic();
+    checkScene();
+    enemyTurn();
+}
+function enemyTurn(){
+    activateEffects(player,"enemy","TurnStart");
+    activateEnemyEffects("enemy","TurnStart");
+
+    for(let emy of enemy){
+        emy.updateState();
+        emy.action();
+    }
+    for(let proj of projectile){
+        if(isProjectileTriggered(proj))triggerProjectile(proj);
+    }
+    activateEffects(player,"enemy","TurnMiddle");
+    activateEnemyEffects("enemy","TurnMiddle");
+    checkEnemyStat();
+    checkPlayerStat();
+    activateEffects(player,"enemy","TurnEnd");
+    activateEnemyEffects("enemy","TurnEnd");
+    drawBattlefieldStatic();
+    checkScene();
+}
+
+
+    
     
    
-}
+
 
 function drawBattlefieldStatic(){
     clearCanvas();

--- a/player.js
+++ b/player.js
@@ -35,6 +35,17 @@ var player={
         },
         
     },
+    action(act,target){
+        switch(act){
+            case "move":
+            playerMove(target.direction);
+            break;
+            case "halt":
+                break;
+            case "skill":
+                playSkill()
+        }
+    },
     attack(target){
         if(distanceBetweenEntity(this,target)<=this.atkR&&!isPathBlocked(this.X,this.Y,target.X,target.Y)){
             this.dealDamageTo(target,this.atk,false);
@@ -50,7 +61,7 @@ var player={
         displayDescription(this);
     },
     onClick(){
-        drawBattlefield();
+        playerTurn();
     },
     dealDamageTo(target,damage,isMagic){
         if(isMagic){
@@ -95,7 +106,7 @@ function playerMove(direction){
         player.Y=ytemp;
     }
     if(currentStage=="battle"){
-        requestAnimationFrame(drawBattlefield);
+        playerTurn();
     }
 }
 function playerMoveByClick(x,y){
@@ -113,21 +124,11 @@ function playerMoveByClick(x,y){
         player.Y=y;
     }
     if(currentStage=="battle"){
-        requestAnimationFrame(drawBattlefield);
+        playerTurn();
     }
 }
 
-//已弃用
-function playerAttack(){
-    for(let i=1;i<=enemyCount;i++){
-        if(enemy[i].isDefeat){
-            continue;
-        }
-        if(distanceEnemyToPlayer(i)<=player.atkR&&!isPathBlocked(enemy[i].X,enemy[i].Y,player.X,player.Y)){
-            dealDamage(i,player.atk,false);
-        }
-    }
-}
+
 function playerHeal(hp){
     player.hp=Math.min(player.hp+hp,player.mhp);
 }

--- a/projectile.js
+++ b/projectile.js
@@ -1,7 +1,7 @@
 var projectile=[];
-var projectileType={};
+var projectileType=new Map();
 var projectileCount=0;
-projectileType.fireball={
+projectileType.set("fireball",{
     id:"fireball",
     source:"fireball.png",
     X:0,
@@ -26,10 +26,10 @@ projectileType.fireball={
             text:"fireball"
         }
     }
-}
+});
 function createProjectile(projId,sx,sy,dx,dy,damage,isFriendly){
     projectileCount++;
-    let type=projectileType[projId];
+    let type=projectileType.get(projId);
     projectile.push({
         id:type.id,
         number:projectileCount,
@@ -55,7 +55,7 @@ function createProjectile(projId,sx,sy,dx,dy,damage,isFriendly){
     })
 }
 function projectileMove(){
-    projectile.forEach(proj=>{
+    for(let proj of projectile){
         let tempX=proj.X,tempY=proj.Y;
         for(let i=0;i<proj.speed*2;i++){
             tempX+=0.5*proj.direction.X;
@@ -65,31 +65,28 @@ function projectileMove(){
             proj.Y=floor(tempY);
             if(isProjectileTriggered(proj)){
                 triggerProjectile(proj);
-                return;
+                break;
             }
         }
         proj.X=tempX;
         proj.Y=tempY;
-    })
+    }
 }
 function isProjectileTriggered(proj){
-    let sign=0;
     if(!isPosLegal(proj.X,proj.Y)) return true;
     if(proj.isFriendly){
-        enemy.forEach(emy=>{
+        for(let emy of enemy){
             if(distanceBetweenEntity(emy,proj)<proj.triggerR&&emy.isDefeat==0){
-                sign=1;
+                return 1;
             }
-        })
-    }else if(distanceBetweenEntity(player,proj)<proj.triggerR) sign=1;
-    if(sign) return true;
-    block.forEach(bloc=>{
-        if(distanceBetweenEntity(bloc,proj)<1&&bloc.isOnField&&!bloc.isProjectilePassable){
-            sign=1;
         }
-    })
-    if(sign) return true;
-    else return false;
+    }else if(distanceBetweenEntity(player,proj)<proj.triggerR) return 1;
+    for(let bloc of block){
+        if(distanceBetweenEntity(bloc,proj)<1&&bloc.isOnField&&!bloc.isProjectilePassable){
+            return 1;
+        }
+    }
+    return 0;
 }
 function triggerProjectile(proj){
     if(proj.isAOE&&proj.isFriendly){
@@ -101,12 +98,12 @@ function triggerProjectile(proj){
     }else if(proj.isFriendly){
         let minD=999;
         let target={};
-        enemy.forEach(emy=>{
+        for(let emy of enemy){
             if(distanceBetweenEntity(proj,emy)<minD){
                 minD=distanceBetweenEntity(proj,emy);
                 target=emy;
             }
-        })
+        }
         if(target!={}) dealDamage(target,proj.damage,proj.isMagic);
     }
     projectile.splice(projectile.findIndex(p=>p.number==proj.number),1);

--- a/skill.js
+++ b/skill.js
@@ -1,8 +1,8 @@
-var skill=[];
+var skill=new Map();
 var skillCount=0;
 var skillReady=0;
-var skillType=[];
-skillType.push({
+var skillType=new Map();
+skillType.set("fireball",{
     id:"fireball",
     spell:fireball,
     cost:5,
@@ -33,7 +33,7 @@ skillType.push({
         ;
     }
 });
-skillType.push({
+skillType.set("flashmove",{
     id:"flashmove",
     spell:flashmove,
     cost:5,
@@ -64,7 +64,7 @@ skillType.push({
         ;
     }
 });
-skillType.push({
+skillType.set("sacriStrike",{
     id:"sacriStrike",
     spell:sacrificialStrike,
     cost:0,
@@ -93,7 +93,7 @@ skillType.push({
         ;
     }
 });
-skillType.push({
+skillType.set("heal",{
     id:"heal",
     spell:heal,
     cost:10,
@@ -125,10 +125,10 @@ skillType.push({
     }
 });
 function addSkill(typeName){
-    let type=skillType.find((element)=>element.id==typeName);
+    let type=skillType.get(typeName);
     if(skillCount<9){
         skillCount++;
-        skill[skillCount]={
+        skill.set(skillCount,{
             id:type.id,
             number:skillCount,
             spell:type.spell,
@@ -158,18 +158,31 @@ function addSkill(typeName){
                 displayDescription(this);
             },
             onClick(){
-                playSkill(this);
+                prepareSkill(this);
             }
-        }
+        })
         return 1;
     }
     return 0;
 }
 
-function playSkill(skill1){
+function prepareSkill(skillId){
+    if(skillReady!=0){
+       skill.get(skillReady).isSelected=0;
+       skillReady=0;    
+    }
+    
     let skil;
-    if(typeof skill1=="number"&&skill1>=1&&skill1<=skillCount) skil=skill[skill1];
-    else if(typeof skill1=="object") skil=skill1;
+    if(typeof skillId=="number"&&skillId>=1&&skillId<=9){
+        for(let [id,item] of skill){
+            skillId--;
+            if(skillId==0){
+                skil=item;
+                break;
+            }
+        }
+    }
+    else if(typeof skillId=="object") skil=skillId;
     else return 0;
     if(actionCooldown){
         return 0;
@@ -181,25 +194,22 @@ function playSkill(skill1){
         return 0;
     }
     if(skil.cost>player.mp){
-        console.log("Cast Failed: No Enough MP");
+        console.log("No Enough MP");
         return 0;
     }
     else{
-        if(skillReady!=0){
-            skill[skillReady].isSelected=0;
-        }
         actionCooldown=1;
         setTimeout(()=>{actionCooldown=0;},100);
         skillReady=skil.number;
         skil.isSelected=1;
         drawBattlefieldStatic();
         skil.drawSelector(mouseX,mouseY);
-        return skil.number;
+        return skillReady;
     }
 } 
 function cdDown(t){
-    for(let i=1;i<=skillCount;i++){
-        skill[i].cdt=Math.max(skill[i].cdt-t,0);
+    for(let [id,skil] of skill){
+        skil.cdt=max(skil.cdt-t,0);
     }
 }
 //skills
@@ -215,7 +225,7 @@ function flashmove(event){
         player.X=x;
         player.Y=y;
         if(isPosAvaliableLE1(x,y)&&isPosLegal(x,y)){
-            requestAnimationFrame(drawBattlefield);
+            playerTurn();
             return 1;
         }
         else{
@@ -236,7 +246,7 @@ function fireball(event){
             return 0;
         }
         createProjectile("fireball",player.X,player.Y,dx,dy,player.mat*2,true);
-        requestAnimationFrame(drawBattlefield);
+        playerTurn();
         return 1;
     }
     else{
@@ -254,7 +264,7 @@ function sacrificialStrike(event){
                 dealDamage(emy,player.atk*5.5,false);
             }
         })
-        requestAnimationFrame(drawBattlefield);
+        playerTurn();
         return 1;
     }
 }

--- a/wastebin.js
+++ b/wastebin.js
@@ -1,4 +1,15 @@
 //已弃用
+function playerAttack(){
+    for(let i=1;i<=enemyCount;i++){
+        if(enemy[i].isDefeat){
+            continue;
+        }
+        if(distanceEnemyToPlayer(i)<=player.atkR&&!isPathBlocked(enemy[i].X,enemy[i].Y,player.X,player.Y)){
+            dealDamage(i,player.atk,false);
+        }
+    }
+}
+//已弃用
 function enemyMove(count,direction){
     let xtemp=enemy[count].X;
     let ytemp=enemy[count].Y;


### PR DESCRIPTION
Convert several array/object registries to Map (character, enemyType, effectType, projectileType, skillType, skill) and update consuming code to use Map APIs. Introduce a three-phase turn flow (playerTurn, neutralTurn, enemyTurn) and rename effect callbacks to per-role/per-phase handlers (playerTurnStart/Middle/End, neutral..., enemy...). Replace many forEach loops with for/of or Map iteration and early returns for event/selector handling. Misc fixes: checkScene now checks enemy.length, addEnemy accepts type id, skill selection/prepare flow adjusted, projectile and cooldown handling integrated into the new turn flow. Deprecated playerAttack moved to wastebin. These changes reorganize effect lifecycles and turn orchestration for clearer, role-specific processing and fix related bugs.